### PR TITLE
fix(1358): add trailing zero when mask="separator.1" and leadZero="true"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 17.0.8(2024-04-30)
+
+### Fix
+
+-   Fix ([#1358](https://github.com/JsDaddy/ngx-mask/issues/1358))
+
 # 17.0.7(2024-03-28)
 
 ### Fix

--- a/projects/ngx-mask-lib/package.json
+++ b/projects/ngx-mask-lib/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ngx-mask",
-    "version": "17.0.7",
+    "version": "17.0.8",
     "description": "awesome ngx mask",
     "keywords": [
         "ng2-mask",

--- a/projects/ngx-mask-lib/src/lib/ngx-mask.service.ts
+++ b/projects/ngx-mask-lib/src/lib/ngx-mask.service.ts
@@ -713,7 +713,7 @@ export class NgxMaskService extends NgxMaskApplierService {
         const separatorPrecision = separatorExpression.slice(10, 11);
         if (
             separatorExpression.indexOf('2') > 0 ||
-            (this.leadZero && Number(separatorPrecision) > 1)
+            (this.leadZero && Number(separatorPrecision) > 0)
         ) {
             if (this.decimalMarker === MaskExpression.COMMA && this.leadZero) {
                 // eslint-disable-next-line no-param-reassign

--- a/projects/ngx-mask-lib/src/test/separator.spec.ts
+++ b/projects/ngx-mask-lib/src/test/separator.spec.ts
@@ -588,6 +588,57 @@ describe('Separator: Mask', () => {
         equal('0@', '0', fixture);
     });
 
+    it('should add trailing zero when separator.1 and leadZero = true', fakeAsync(() => {
+        component.mask = 'separator.1';
+        component.leadZero = true;
+        const debugElement: DebugElement = fixture.debugElement.query(By.css('input'));
+        const inputTarget: HTMLInputElement = debugElement.nativeElement as HTMLInputElement;
+        spyOnProperty(document, 'activeElement').and.returnValue(inputTarget);
+        fixture.detectChanges();
+
+        component.form.setValue(0);
+        tick();
+        expect(inputTarget.value).toBe('0.0');
+
+        component.form.setValue(1);
+        tick();
+        expect(inputTarget.value).toBe('1.0');
+
+        component.form.setValue(88);
+        tick();
+        expect(inputTarget.value).toBe('88.0');
+
+        component.form.setValue(99.);
+        tick();
+        expect(inputTarget.value).toBe('99.0');
+    }));
+
+    it('should not modify value with one decimal when separator.1 and leadZero = true', fakeAsync(() => {
+        component.mask = 'separator.1';
+        component.leadZero = true;
+        const debugElement: DebugElement = fixture.debugElement.query(By.css('input'));
+        const inputTarget: HTMLInputElement = debugElement.nativeElement as HTMLInputElement;
+        spyOnProperty(document, 'activeElement').and.returnValue(inputTarget);
+        fixture.detectChanges();
+
+        component.form.setValue(0.0);
+        tick();
+        expect(inputTarget.value).toBe('0.0');
+
+        component.form.setValue(1.0);
+        tick();
+        expect(inputTarget.value).toBe('1.0');
+
+        component.form.setValue(88.0);
+        tick();
+        expect(inputTarget.value).toBe('88.0');
+
+        component.form.setValue(99.9);
+        tick();
+        expect(inputTarget.value).toBe('99.9');
+    }));
+
+
     it('should display zeros at the end separator2', fakeAsync(() => {
         component.mask = 'separator.2';
         component.leadZero = true;


### PR DESCRIPTION
Currently, no trailing zero is added when mask="separator.1" and leadZero="true" and input loses focus. This change adds the trailing zero in that case.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/JsDaddy/ngx-mask/blob/develop/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

When `mask="separator.1"` and `leadZero="true"`, the input's value doesn't change when there is no decimal and the input loses focus. So, if `1` is entered in this case, the value remains `1` but the desired result is that the value would be changed to `1.0`.

Issue Number: #1358

## What is the new behavior?

When `1` is entered and the input loses focus, the value is replaced with `1.0`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No